### PR TITLE
final pop up, potential bug fix

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -772,10 +772,16 @@ function mousePressed() {
       startGame();
     } else if (mouseInside(backToMenuButton)) {
       playMenuSFX();
-      gameState = "menu";
-      gameEvents.Fire("gameOver", false);
+      //bug fix for pop up
+      if (finalRoundPopup && typeof finalRoundPopup.close === "function") {
+        finalRoundPopup.close();
+      }
       finalRoundPopupShown = false;
+      shownGameOverScreen = false;
+      gameOver = false;
+
       playMenuBGM();
+      gameState = "menu";
     }
   } else if (gameState === "builder") {
     if (mouseInside(backButton)) {


### PR DESCRIPTION
when I clicked the back button
from the final round pop up screen, the pop up covered the menu. If this is not a problem for
other versions, ignore please